### PR TITLE
Add fluid tank style compost tower

### DIFF
--- a/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostTowerBlockEntity.java
+++ b/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostTowerBlockEntity.java
@@ -16,6 +16,15 @@ public class CompostTowerBlockEntity extends FluidTankBlockEntity {
         super(type, pos, state);
     }
 
+    /**
+     * Make connectivity updates callable from {@link CompostTowerBlock}
+     * where the original protected visibility prevents access.
+     */
+    @Override
+    public void updateConnectivity() {
+        super.updateConnectivity();
+    }
+
     @Override
     protected SmartFluidTank createInventory() {
         return new SmartFluidTank(1000, this::onFluidStackChanged);

--- a/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostTowerModel.java
+++ b/src/main/java/org/forsteri/ratatouille/content/compost_tower/CompostTowerModel.java
@@ -1,0 +1,132 @@
+package org.forsteri.ratatouille.content.compost_tower;
+
+import com.simibubi.create.api.connectivity.ConnectivityHandler;
+import com.simibubi.create.content.fluids.tank.FluidTankCTBehaviour;
+import com.simibubi.create.content.fluids.tank.FluidTankGenerator;
+import com.simibubi.create.foundation.block.connected.CTModel;
+import com.simibubi.create.foundation.block.connected.CTSpriteShiftEntry;
+import com.tterrag.registrate.providers.DataGenContext;
+import com.tterrag.registrate.providers.RegistrateBlockstateProvider;
+import net.createmod.catnip.data.Iterate;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.model.data.ModelData;
+import net.minecraftforge.client.model.data.ModelProperty;
+import net.minecraftforge.client.model.generators.ModelFile;
+import org.forsteri.ratatouille.entry.CRSpriteShifts;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class CompostTowerModel extends CTModel {
+    public static CompostTowerModel standard(BakedModel originalModel) {
+        return new CompostTowerModel(originalModel,
+                CRSpriteShifts.COMPOST_TOWER, CRSpriteShifts.COMPOST_TOWER_TOP, CRSpriteShifts.COMPOST_TOWER_TOP_INNER,
+                CRSpriteShifts.COMPOST_TOWER_BOTTOM, CRSpriteShifts.COMPOST_TOWER_BOTTOM_INNER,
+                CRSpriteShifts.COMPOST_TOWER_SHIFT_2x2);
+    }
+
+    public CompostTowerModel(BakedModel originalModel, CTSpriteShiftEntry side, CTSpriteShiftEntry top,
+                             CTSpriteShiftEntry topInner, CTSpriteShiftEntry bottom, CTSpriteShiftEntry bottomInner,
+                             CTSpriteShiftEntry shift2x2) {
+        super(originalModel, new CompostTowerCTBehavior(side, top, topInner, bottom, bottomInner, shift2x2));
+    }
+
+    public static class CompostTowerCTBehavior extends FluidTankCTBehaviour {
+        private final CTSpriteShiftEntry bottomShift;
+        private final CTSpriteShiftEntry bottomInnerShift;
+        private final CTSpriteShiftEntry shift2x2;
+
+        public CompostTowerCTBehavior(CTSpriteShiftEntry layerShift, CTSpriteShiftEntry topShift, CTSpriteShiftEntry innerShift,
+                                      CTSpriteShiftEntry bottom, CTSpriteShiftEntry bottomInner, CTSpriteShiftEntry shift2x2) {
+            super(layerShift, topShift, innerShift);
+            this.bottomShift = bottom;
+            this.bottomInnerShift = bottomInner;
+            this.shift2x2 = shift2x2;
+        }
+
+        @Override
+        public CTSpriteShiftEntry getShift(BlockState state, Direction direction, @Nullable TextureAtlasSprite sprite) {
+            if (sprite != null && direction.getAxis() == Direction.Axis.Y && bottomShift.getOriginal() == sprite)
+                return bottomShift;
+            if (sprite != null && direction.getAxis() == Direction.Axis.Y && bottomInnerShift.getOriginal() == sprite)
+                return bottomInnerShift;
+            return super.getShift(state, direction, sprite);
+        }
+    }
+
+    protected static final ModelProperty<CullData> CULL_PROPERTY = new ModelProperty<>();
+
+    @Override
+    protected ModelData.Builder gatherModelData(ModelData.Builder builder, BlockAndTintGetter world, BlockPos pos, BlockState state,
+                                                ModelData blockEntityData) {
+        super.gatherModelData(builder, world, pos, state, blockEntityData);
+        CullData cullData = new CullData();
+        for (Direction d : Iterate.directions) {
+            cullData.setCulled(d, ConnectivityHandler.isConnected(world, pos, pos.relative(d)));
+        }
+
+        cullData.setCulled(null, !(ConnectivityHandler.isConnected(world, pos, pos.above()) ||
+                ConnectivityHandler.isConnected(world, pos, pos.below())));
+
+        return builder.with(CULL_PROPERTY, cullData);
+    }
+
+    @Override
+    public @NotNull List<BakedQuad> getQuads(BlockState state, Direction side, RandomSource rand, ModelData extraData, RenderType renderType) {
+        if (side != null)
+            return Collections.emptyList();
+
+        List<BakedQuad> quads = new ArrayList<>();
+        for (Direction d : Iterate.directions) {
+            if (extraData.has(CULL_PROPERTY) && Objects.requireNonNull(extraData.get(CULL_PROPERTY))
+                    .isCulled(d))
+                continue;
+            quads.addAll(super.getQuads(state, d, rand, extraData, renderType));
+        }
+
+        if (extraData.has(CULL_PROPERTY) && !Objects.requireNonNull(extraData.get(CULL_PROPERTY))
+                .isCulled(null))
+            quads.addAll(super.getQuads(state, null, rand, extraData, renderType));
+        return quads;
+    }
+
+    private static class CullData {
+        Map<Direction, Boolean> culledFaces = new HashMap<>();
+
+        public CullData() {
+            for (Direction d : Iterate.directions)
+                culledFaces.put(d, false);
+        }
+
+        void setCulled(Direction face, boolean cull) {
+            culledFaces.put(face, cull);
+        }
+
+        boolean isCulled(Direction face) {
+            return culledFaces.get(face);
+        }
+    }
+
+    public static class CompostTowerGenerator extends FluidTankGenerator {
+        protected ModelFile model = null;
+
+        @Override
+        public <T extends Block> ModelFile getModel(DataGenContext<Block, T> ctx, RegistrateBlockstateProvider prov,
+                                                    BlockState state) {
+            if (model != null)
+                return model;
+            return model = prov.models()
+                    .getExistingFile(prov.modLoc(ctx.getName()));
+        }
+    }
+}

--- a/src/main/java/org/forsteri/ratatouille/entry/CRBlocks.java
+++ b/src/main/java/org/forsteri/ratatouille/entry/CRBlocks.java
@@ -13,6 +13,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.material.MapColor;
 import org.forsteri.ratatouille.Ratatouille;
 import org.forsteri.ratatouille.content.compost_tower.CompostTowerBlock;
+import org.forsteri.ratatouille.content.compost_tower.CompostTowerModel;
 import org.forsteri.ratatouille.content.demolder.MechanicalDemolderBlock;
 import org.forsteri.ratatouille.content.frozen_block.FrozenBlock;
 import org.forsteri.ratatouille.content.irrigation_tower.IrrigationTowerBlock;
@@ -143,7 +144,8 @@ public class CRBlocks {
             .initialProperties(SharedProperties::copperMetal)
             .properties(p -> p.lightLevel(state -> 1).noOcclusion().isRedstoneConductor((p1, p2, p3) -> true))
             .transform(pickaxeOnly())
-            .blockstate(BlockStateGen.horizontalBlockProvider(true))
+            .blockstate(new CompostTowerModel.CompostTowerGenerator()::generate)
+            .onRegister(CreateRegistrate.blockModel(() -> CompostTowerModel::standard))
             .addLayer(() -> RenderType::cutoutMipped)
             .item()
             .model((c, p) -> p.withExistingParent(c.getName(), new ResourceLocation(Ratatouille.MOD_ID, "block/compost_tower/item")))

--- a/src/main/java/org/forsteri/ratatouille/entry/CRSpriteShifts.java
+++ b/src/main/java/org/forsteri/ratatouille/entry/CRSpriteShifts.java
@@ -12,7 +12,13 @@ public class CRSpriteShifts {
             OVEN_SPRITE_TOP_INNER = getCT("oven/oven_top_inner"),
             OVEN_SPRITE_BOTTOM = getCT("oven/oven_bottom"),
             OVEN_SPRITE_BOTTOM_INNER = getCT("oven/oven_bottom_inner"),
-            OVEN_SPRITE_SHIFT_2x2 = getCT("oven/oven", "oven/oven_2x2");
+            OVEN_SPRITE_SHIFT_2x2 = getCT("oven/oven", "oven/oven_2x2"),
+            COMPOST_TOWER = getCT("compost_tower/compost_tower"),
+            COMPOST_TOWER_TOP = getCT("compost_tower/compost_tower_top"),
+            COMPOST_TOWER_TOP_INNER = getCT("compost_tower/compost_tower_top_inner"),
+            COMPOST_TOWER_BOTTOM = getCT("compost_tower/compost_tower_bottom"),
+            COMPOST_TOWER_BOTTOM_INNER = getCT("compost_tower/compost_tower_bottom_inner"),
+            COMPOST_TOWER_SHIFT_2x2 = getCT("compost_tower/compost_tower", "compost_tower/compost_tower_2x2");
 
     private static CTSpriteShiftEntry getCT(String blockTextureName, String connectedTextureName) {
         return CTSpriteShifter.getCT(AllCTTypes.RECTANGLE, new ResourceLocation(Ratatouille.MOD_ID, "block/" + blockTextureName),


### PR DESCRIPTION
## Summary
- switch `CompostTowerBlock` to a nondirectional block
- form multiblock towers using `ConnectivityHandler`
- render multiblock towers with new `CompostTowerModel`
- register connected textures for the new tower
- expose `updateConnectivity` in `CompostTowerBlockEntity`

## Testing
- `./gradlew build -x test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d9054d6388321a0e7d5d82e4c12d2